### PR TITLE
35 Fix Style bug (Make MapControl functional component)

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -45,7 +45,7 @@ html, body {
 
   p {
     padding: 5px;
-    line-height: 2;
+    line-height: 1.25;
   }
   
   img {
@@ -158,11 +158,11 @@ html, body {
 
 .toggle-instructions {
   background-color: var(--red-color);
-  width: 40px;
-  height: 40px;
+  width: 35px;
+  height: 35px;
   border: 3px solid var(--white);
   border-radius: 5px;
-  margin: 0px 10px;
+  margin: 0px 3px;
 }
 
 .map-toggle-container {

--- a/src/components/InstructionPopup.js
+++ b/src/components/InstructionPopup.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import NegativeIssLogo from '../images/ISS.png';
 import observatoryLogo from '../images/observatory.png';
 import eventLogo from '../images/event.png';
+import lightLogo from '../images/light.jpg';
 
 class InstructionPopup extends Component {
   render() {
@@ -10,6 +11,7 @@ class InstructionPopup extends Component {
         <h1>International Space Station (ISS) Tracker</h1>
         <p>Toggle markers with the Observatory and Event buttons<img src={observatoryLogo} alt="Observatory Toggle" className="toggle-instructions" /><img src={eventLogo} alt="Event Toggle" className="toggle-instructions" /></p>
         <p>Click markers <img src={NegativeIssLogo} alt="(ISS LOGO)" className="iss-marker marker" /> <img src={observatoryLogo} alt="Observatory Marker" className="observatory-marker marker" /> <img src={eventLogo} alt="Event Marker" className="event-marker marker" /> for more info</p>
+        <p>Change the Map style with the <img src={lightLogo} alt="Style Toggle" className="toggle-instructions" /> button</p>
         <p>The position of the ISS is updated every 3 seconds</p>
         <h2>(Click to Proceed)</h2>
       </div>

--- a/src/components/MapToggleControl.js
+++ b/src/components/MapToggleControl.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import PropTypes from 'prop-types';
+import MapStyleButton from './MapStyleButton';
+import streetsLogo from '../images/streets.jpg'
+import lightLogo from '../images/light.jpg'
+import darkLogo from '../images/dark.jpg'
+import satelliteLogo from '../images/satellite.jpg'
+
+function MapToggleControl (props) {
+
+  const handleMapClick = () => {
+    let style = props.style;
+    if (style === "streets-v11") {
+      return <MapStyleButton image={streetsLogo} text={"streets"} onClick={handleMapClick} />
+    } else if (style === "light-v10") {
+      return <MapStyleButton image={lightLogo} text={"light"} onClick={handleMapClick} />
+    } else if (style === "dark-v10") {
+      return <MapStyleButton image={darkLogo} text={"dark"} onClick={handleMapClick} />
+    } else if (style === "satellite-v9") {
+      return <MapStyleButton image={satelliteLogo} text={"satellite"} onClick={handleMapClick} />
+    }
+  }
+
+  return (
+    <div>
+      {handleMapClick()}
+    </div>
+  )
+}
+
+MapToggleControl.propTypes = {
+  name: PropTypes.string
+};
+
+export default MapToggleControl

--- a/src/components/Mapbox.js
+++ b/src/components/Mapbox.js
@@ -3,6 +3,7 @@ import mapboxgl from 'mapbox-gl';
 import axios from 'axios';
 import FollowControl from './FollowControl'
 import MarkerToggleControl from './MarkerToggleControl';
+import MapToggleControl from './MapToggleControl';
 import InstructionPopup from './InstructionPopup';
 
 require('dotenv').config();
@@ -250,7 +251,7 @@ class Mapbox extends Component {
           <MarkerToggleControl name={"Instructions"} />
         </div>
         <div onClick={this.toggleMap}>
-          <MarkerToggleControl name={"Map"} />
+          <MapToggleControl name={"Map"} style={`${this.state.mapStyles[this.state.mapStyleIndex]}`}/>
         </div>
         <div onClick={this.toggleEvents}>
           <MarkerToggleControl name={"Events"} />

--- a/src/components/MarkerToggleControl.js
+++ b/src/components/MarkerToggleControl.js
@@ -2,13 +2,8 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types';
 import ShowMarkerButton from './ShowMarkerButton';
 import HideMarkerButton from './HideMarkerButton';
-import MapStyleButton from './MapStyleButton';
 import eventsLogo from '../images/event.png'
 import observatoryLogo from '../images/observatory.png'
-import streetsLogo from '../images/streets.jpg'
-import lightLogo from '../images/light.jpg'
-import darkLogo from '../images/dark.jpg'
-import satelliteLogo from '../images/satellite.jpg'
 import instructionsLogo from '../images/instructions.png'
 
 class MarkerToggleControl extends Component {
@@ -64,21 +59,6 @@ class MarkerToggleControl extends Component {
 
     if (buttonName === 'Instructions') {
       button = <HideMarkerButton image={instructionsLogo} name={"instructions"} />;
-    }
-
-    if (buttonName === "Map") {
-      switch (this.state.index) {
-        case 0:
-          return button = <MapStyleButton image={lightLogo} text={"light"} onClick={this.handleMapClick} />;
-        case 1:
-          return button = <MapStyleButton image={darkLogo} text={"dark"} onClick={this.handleMapClick} />;
-        case 2:
-          return button = <MapStyleButton image={satelliteLogo} text={"satellite"}  onClick={this.handleMapClick} />;
-        case 3:
-          return button = <MapStyleButton image={streetsLogo} text={"streets"} onClick={this.handleMapClick} />;
-        default:
-          return button = <MapStyleButton image={streetsLogo} text={"streets"} onClick={this.handleMapClick} />;
-      }
     }
 
     return (


### PR DESCRIPTION
# PR Documentation

## Fixes #35  

## Type of change
- [x] :beetle: Bug fix (non-breaking change which fixes an issue)
- [ ] :hatching_chick: New feature (non-breaking change which adds functionality)
- [ ] :page_with_curl: This change requires a documentation update

## Summary of changes
- Update how the map style toggle gets rendered by changing it to its own functional `MapToggleControl` component
  - This way nothing is caught up in state and the button that appears directly depends on the style being shown instead of having its own state and counter
    - This seemed much cleaner, more efficient, and less likely to be buggy
- Add map style info to `InstructionsPopup` component and change the corresponding SCSS styles to render better for mobile

## How Has This Been Tested?
- [ ] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [x] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [ ] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes
