### PR TITLE
48 Update lat and lon of Event Popups

### DIFF
--- a/src/components/Mapbox.js
+++ b/src/components/Mapbox.js
@@ -226,8 +226,8 @@ class Mapbox extends Component {
               .setHTML(`
               <h3> ${event.properties.title}</h3>
               <h4> ${event.properties.categories[0].title}</h4>
-              <p>Latitude: ${event.geometry.coordinates[0]}</p>
-              <p>Longitude: ${event.geometry.coordinates[1]}</p>
+              <p>Latitude: ${event.geometry.coordinates[1]}</p>
+              <p>Longitude: ${event.geometry.coordinates[0]}</p>
               <a href="${event.properties.sources[0].url}" >More Info</a>
               `))
             .addTo(mapboxMap)


### PR DESCRIPTION
# PR Documentation

## Fixes #48 

## Type of change
- [ ] :beetle: Bug fix (non-breaking change which fixes an issue)
- [ ] :hatching_chick: New feature (non-breaking change which adds functionality)
- [ ] :page_with_curl: This change requires a documentation update

## Summary of changes
- Update lat and lon of Event Popups because they were switched and displaying in reverse

## How Has This Been Tested?
- [ ] :black_square_button: Integration testing
- [ ] :white_square_button: Unit testing

## Checklist:
- [x] :white_check_mark: I have performed a self-review of my own code
- [x] :eight_spoked_asterisk: I have commented my code, particularly in hard-to-understand areas
- [ ] :page_facing_up: I have made corresponding changes to the documentation
- [x] :no_entry_sign: My changes generate no new warnings
- [ ] :heavy_check_mark: I have added tests that prove my fix is effective or that my feature works
- [x] :100: New and existing unit tests pass locally with my changes
